### PR TITLE
Migration to add user:reference to experiences table

### DIFF
--- a/db/migrate/20180529073115_add_user_reference_to_experiences.rb
+++ b/db/migrate/20180529073115_add_user_reference_to_experiences.rb
@@ -1,0 +1,5 @@
+class AddUserReferenceToExperiences < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :experiences, :user, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_05_28_163238) do
+ActiveRecord::Schema.define(version: 2018_05_29_073115) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,6 +36,8 @@ ActiveRecord::Schema.define(version: 2018_05_28_163238) do
     t.string "photo"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_experiences_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -60,4 +62,5 @@ ActiveRecord::Schema.define(version: 2018_05_28_163238) do
 
   add_foreign_key "bookings", "experiences"
   add_foreign_key "bookings", "users"
+  add_foreign_key "experiences", "users"
 end


### PR DESCRIPTION
Added user_reference to experience table, so it is in line with the model relationships. Each experience belongs to a user, linked through its id.