### PR TITLE
index page with seeded data

### DIFF
--- a/app/controllers/experiences_controller.rb
+++ b/app/controllers/experiences_controller.rb
@@ -2,6 +2,7 @@ class ExperiencesController < ApplicationController
   before_action :set_experience, only: [:show, :edit, :update, :destroy]
 
   def index
+    @experiences = Experience.all.limit(15)
   end
 
   def show

--- a/app/views/experiences/index.html.erb
+++ b/app/views/experiences/index.html.erb
@@ -1,22 +1,10 @@
+
 <div class="card-grid">
   <div class="row no-gutters">
-    <div class="col-sm-6">
-      <%= render 'shared/card' %>
-    </div>
-    <div class="col-sm-6">
-      <%= render 'shared/card' %>
-    </div>
-  </div>
-
-  <div class="row no-gutters">
+    <% @experiences.each do |experience| %>
     <div class="col-sm-4">
-      <%= render 'shared/card' %>
+      <%= render partial: "shared/card", :locals => {experience: experience}%>
     </div>
-    <div class="col-sm-4">
-      <%= render 'shared/card' %>
-    </div>
-    <div class="col-sm-4">
-      <%= render 'shared/card' %>
-    </div>
+    <%end%>
   </div>
 </div>

--- a/app/views/shared/_card.html.erb
+++ b/app/views/shared/_card.html.erb
@@ -1,15 +1,19 @@
 <div class="card">
-  <div class="card-body" style="background-image: linear-gradient(rgba(0,0,0,0.05), rgba(0,0,0,0)), url('http://via.placeholder.com/450x250');">
-  <span class="card-category">Sport</span>
+  <div class="card-body" style="background-image: linear-gradient(rgba(0,0,0,0.05), rgba(0,0,0,0)), url(<%=experience.photo%>);">
+  <span class="card-category"><%=experience.category%></span>
       <div class="card-description">
-        <h2>Go play football</h2>
-        <p>with locals</p>
+        <h2><%=experience.title%></h2>
+        <p>duration: <%=experience.duration%>h</p>
       </div>
-      <img class="card-user avatar avatar-large" src="http://via.placeholder.com/80x80">
-      <a class="card-link" href="#" ></a>
+       <% if experience.user.photo.url == nil %>
+          <i class="far fa-user card-user avatar avatar-large"></i>
+          <% else %>
+          <%= image_tag experience.user.photo.url(:thumnail), :class => "far fa-user card-user avatar avatar-large"%>
+        <%end%>
+      <%=link_to "", experience_path(experience), :class => "card-link" %>
   </div>
   <div class="card-footer">
-    <p>15€ in Lisbon, Campolide</p>
+    <p><%=experience.price%>€ in <%=experience.address%></p>
     <div class="controls">
       <a href="#"><i class="fa fa-star"></i></a>
       <a href="#"><i class="fa fa-share"></i></a>


### PR DESCRIPTION
simple 4- 4- 4 rows now (no 6-6 rows in between). Will be implemented later.
With different text length the card size is changing. I think the "max-height" of the card-footer has to be fixed.

Profile picture of experience creator is only symbol because uploaded file not available.

![screen shot 2018-05-29 at 17 47 19](https://user-images.githubusercontent.com/18689487/40673006-6290fd68-6368-11e8-9c47-55368f9e05fa.png)
